### PR TITLE
Change covariance array size from 32 to 36

### DIFF
--- a/RosBridgeClient/Message.cs
+++ b/RosBridgeClient/Message.cs
@@ -132,7 +132,7 @@ namespace RosSharp.RosBridgeClient
         public GeometryPoseWithCovariance()
         {
             pose = new GeometryPose();
-            covariance = new float[32];
+            covariance = new float[36];
         }
     }
     public class GeometryTwistWithCovariance : Message
@@ -142,7 +142,7 @@ namespace RosSharp.RosBridgeClient
         public GeometryTwistWithCovariance()
         {
             twist = new GeometryTwist();
-            covariance = new float[32];
+            covariance = new float[36];
         }
     }
 


### PR DESCRIPTION
The covariance array represents a 6x6 matrix, so the size should be 36.

See also http://docs.ros.org/api/geometry_msgs/html/msg/PoseWithCovariance.html and http://docs.ros.org/api/geometry_msgs/html/msg/TwistWithCovariance.html