### PR TITLE
Making TwistReceived::ProcessMessage virtual

### DIFF
--- a/Unity3D/Assets/RosSharp/Scripts/MessageHandling/TwistReceiver.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/MessageHandling/TwistReceiver.cs
@@ -24,8 +24,8 @@ namespace RosSharp.RosBridgeClient
     public class TwistReceiver : MessageReceiver
     {
         private float previousRealTime;
-        private Vector3 linearVelocity;
-        private Vector3 angularVelocity;
+        protected Vector3 linearVelocity;
+        protected Vector3 angularVelocity;
         private bool isMessageReceived;
 
         public override Type MessageType { get { return (typeof(GeometryTwist)); } }
@@ -57,7 +57,7 @@ namespace RosSharp.RosBridgeClient
             if (isMessageReceived)
                 ProcessMessage();
         }
-        private void ProcessMessage()
+        protected virtual void ProcessMessage()
         {
             float deltaTime = Time.realtimeSinceStartup-previousRealTime;
             transform.Translate(linearVelocity * deltaTime);


### PR DESCRIPTION
Use case : I want to write a specific ProcessMessage when a twist is received,  for example in my application, to modify the velocity of the four rotors of a quadrotor. 

I therefore thought about using a TwistReceiver  but what is done when a twist is received is actually hard coded in the twist receiver.  Therefore, there is a need to modify what is done by the TwistReceiver::ProcessMessage method. 

I see two possibilities :
1) making TwistReceiver   an abstract class   with ProcessMessage a virtual method  ; And then writting derived classes with their specific ProcessMessage
2) (the one implemented in this pull request)   Keep your "default" ProcessMessage   but add the virtual keywords to allow overriding it.