### PR TITLE
Map joint state by name instead of index.

### DIFF
--- a/Unity3D/Assets/RosSharp/Scripts/MessageHandling/JointStateHandler.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/MessageHandling/JointStateHandler.cs
@@ -21,6 +21,7 @@ namespace RosSharp.RosBridgeClient
     {
         public enum JointTypes { continuous, revolute, prismatic };
         public JointTypes JointType;
+        public string JointName;
         public int JointID;
     }
 }

--- a/Unity3D/Assets/RosSharp/Scripts/MessageHandling/JointStateReceiver.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/MessageHandling/JointStateReceiver.cs
@@ -35,8 +35,18 @@ namespace RosSharp.RosBridgeClient
         {
             message = (SensorJointStates)e.Message;
             for (int i = 0; i < JointStateWriters.Length; i++)
-                JointStateWriters[i].Write(message.position[i]);   
+            {
+                string jointName = JointStateWriters[i].JointName;
+
+                for (int j = 0; j < message.name.Length; j++)
+                {
+                    if (message.name[j] == jointName)
+                    {
+                        JointStateWriters[i].Write(message.position[j]);
+                        break;
+                    }
+                }
+            }
         }
     }
 }
-


### PR DESCRIPTION
Save joint name in the JointStateHandler class and use it for mapping.