### PR TITLE
Change is_bigendian from bool to byte for SensorImage message

### DIFF
--- a/RosBridgeClient/Message.cs
+++ b/RosBridgeClient/Message.cs
@@ -239,7 +239,7 @@ namespace RosSharp.RosBridgeClient
         public int height;
         public int width;
         public string encoding;
-        public bool is_bigendian;
+        public byte is_bigendian;
         public int step;
         public byte[] data;
         public SensorImage()
@@ -248,7 +248,7 @@ namespace RosSharp.RosBridgeClient
             height = 0;
             width = 0;
             encoding = "undefined";
-            is_bigendian = false;
+            is_bigendian = 0;
             step = 0;
             data = new byte[0];
         }


### PR DESCRIPTION
For some reason, is_bigendian is stored as a `uint8` instead of a `bool` for sensor_msgs/Image. See http://docs.ros.org/api/sensor_msgs/html/msg/Image.html