### PR TITLE
added if-check in JointStateSubscriber to handle fixed joints

### DIFF
--- a/Unity3D/Assets/RosSharp/Scripts/RosCommuncation/JointStateSubscriber.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/RosCommuncation/JointStateSubscriber.cs
@@ -29,13 +29,12 @@ namespace RosSharp.RosBridgeClient
 
         protected override void ReceiveMessage(Messages.Sensor.JointState message)
         {
+            int index;
             for (int i = 0; i < message.name.Length; i++)
             {
-                if (JointNames.Contains(message.name[i]))
-                {
-                    JointStateWriters[JointNames.IndexOf(message.name[i])].Write(message.position[i]);
-                }
-
+                index = JointNames.IndexOf(message.name[i]);
+                if (index != -1)
+                    JointStateWriters[index].Write(message.position[i]);
             }
         }
     }

--- a/Unity3D/Assets/RosSharp/Scripts/RosCommuncation/JointStateSubscriber.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/RosCommuncation/JointStateSubscriber.cs
@@ -22,15 +22,21 @@ namespace RosSharp.RosBridgeClient
         public List<string> JointNames;
         public List<JointStateWriter> JointStateWriters;
 
-		protected override void Start()
-		{
-			base.Start();
-		}
-		
+        protected override void Start()
+        {
+            base.Start();
+        }
+
         protected override void ReceiveMessage(Messages.Sensor.JointState message)
         {
             for (int i = 0; i < message.name.Length; i++)
-                JointStateWriters[ JointNames.IndexOf(message.name[i]) ].Write(message.position[i]);
+            {
+                if (JointNames.Contains(message.name[i]))
+                {
+                    JointStateWriters[JointNames.IndexOf(message.name[i])].Write(message.position[i]);
+                }
+
+            }
         }
     }
 }


### PR DESCRIPTION
Added if-check to JointStateSubscriber to handle case where the robot's JointState message contains a joint that does not have an associated JointStateWriter in Unity. This happens when a robot's JointState message contains fixed joints. The Baxter robot does this, for example.