### PR TITLE
Adding texture filenames to ResourceFileURI list.

### DIFF
--- a/Libraries/RosBridgeClient/UrdfImporter.cs
+++ b/Libraries/RosBridgeClient/UrdfImporter.cs
@@ -129,7 +129,10 @@ namespace RosSharp.RosBridgeClient
         private static List<Uri> ReadResourceFileUris(string robotDescription)
         {
             XElement root = XElement.Parse(robotDescription);
-            return (from seg in root.Descendants("mesh") where seg.Attribute("filename") != null select new Uri(seg.Attribute("filename").Value)).ToList();
+            List<Uri> resourceFileUris = new List<Uri>();
+            foreach (string nodeName in new List<string> {"mesh", "texture"})
+                resourceFileUris.AddRange(from seg in root.Descendants(nodeName) where seg.Attribute("filename") != null select new Uri(seg.Attribute("filename").Value));
+            return resourceFileUris;
         }
 
         private List<ServiceReceiver<file_server.GetBinaryFileRequest, file_server.GetBinaryFileResponse>> RequestResourceFiles(List<Uri> resourceFileUris)


### PR DESCRIPTION
Some urdf files provide textures as parts of materials, for example the [PR2](https://github.com/PR2/pr2_common/blob/kinetic-devel/pr2_description/urdf/materials.urdf.xacro) uses

    <material name="Wheel_l">
        <texture filename="package://pr2_description/materials/textures/pr2_wheel_left.png" />
    </material>

These textures would not be requested, resulting in warnings during the mesh import. This pull request changes the ReadResourceFileUris such that it does not only search for `mesh` nodes but also for `texture` nodes.

Further nodes can easily be added in the future.