### PR TITLE
Adding assignedObject to TwistSubscriber, TwistPublisher, and PoseStampedSubscriber

### DIFF
--- a/Unity3D/Assets/RosSharp/Scripts/RosCommuncation/PoseStampedPublisher.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/RosCommuncation/PoseStampedPublisher.cs
@@ -31,7 +31,7 @@ namespace RosSharp.RosBridgeClient
 
         private void FixedUpdate()
         {
-                UpdateMessage();
+            UpdateMessage();
         }
 
         private void InitializeMessage()

--- a/Unity3D/Assets/RosSharp/Scripts/RosCommuncation/PoseStampedSubscriber.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/RosCommuncation/PoseStampedSubscriber.cs
@@ -13,6 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Adding assignedObject.
+// © University of Bremen, 2018, Sebastian Höffner (shoeffner@tzi.de)
+
 using UnityEngine;
 
 namespace RosSharp.RosBridgeClient
@@ -22,12 +25,13 @@ namespace RosSharp.RosBridgeClient
         private Vector3 position;
         private Quaternion rotation;
         private bool isMessageReceived;
+        public GameObject assignedObject;
 
 		protected override void Start()
         {
 			base.Start();
 		}
-		
+
         private void Update()
         {
             if (isMessageReceived)
@@ -43,8 +47,8 @@ namespace RosSharp.RosBridgeClient
 
         private void ProcessMessage()
         {
-            transform.position = position;
-            transform.rotation = rotation;
+            assignedObject.transform.position = position;
+            assignedObject.transform.rotation = rotation;
         }
 
         private Vector3 GetPosition(Messages.Geometry.PoseStamped message)

--- a/Unity3D/Assets/RosSharp/Scripts/RosCommuncation/TwistPublisher.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/RosCommuncation/TwistPublisher.cs
@@ -13,6 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Adding assignedObject.
+// © University of Bremen, 2018, Sebastian Höffner (shoeffner@tzi.de)
+
 using UnityEngine;
 
 namespace RosSharp.RosBridgeClient
@@ -21,9 +24,10 @@ namespace RosSharp.RosBridgeClient
     {
         private Messages.Geometry.Twist message;
 
-        private float previousRealTime;        
+        private float previousRealTime;
         private Vector3 previousPosition = Vector3.zero;
         private Quaternion previousRotation = Quaternion.identity;
+        public GameObject assignedObject;
 
         protected override void Start()
         {
@@ -46,15 +50,15 @@ namespace RosSharp.RosBridgeClient
         {
             float deltaTime = Time.realtimeSinceStartup - previousRealTime;
 
-            Vector3 linearVelocity = (transform.position - previousPosition)/deltaTime;
-            Vector3 angularVelocity = (transform.rotation.eulerAngles - previousRotation.eulerAngles)/deltaTime;
-                
+            Vector3 linearVelocity = (assignedObject.transform.position - previousPosition) / deltaTime;
+            Vector3 angularVelocity = (assignedObject.transform.rotation.eulerAngles - previousRotation.eulerAngles) / deltaTime;
+
             message.linear = GetGeometryVector3(linearVelocity.Unity2Ros()); ;
             message.angular = GetGeometryVector3(- angularVelocity.Unity2Ros());
 
             previousRealTime = Time.realtimeSinceStartup;
-            previousPosition = transform.position;
-            previousRotation = transform.rotation;
+            previousPosition = assignedObject.transform.position;
+            previousRotation = assignedObject.transform.rotation;
 
             Publish(message);
         }

--- a/Unity3D/Assets/RosSharp/Scripts/RosCommuncation/TwistSubscriber.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/RosCommuncation/TwistSubscriber.cs
@@ -16,6 +16,9 @@ limitations under the License.
 // Adjustments to new Publication Timing and Execution Framework
 // © Siemens AG, 2018, Dr. Martin Bischoff (martin.bischoff@siemens.com)
 
+// Adding assignedObject.
+// © University of Bremen, 2018, Sebastian Höffner (shoeffner@tzi.de)
+
 using UnityEngine;
 
 namespace RosSharp.RosBridgeClient
@@ -26,6 +29,7 @@ namespace RosSharp.RosBridgeClient
         private Vector3 linearVelocity;
         private Vector3 angularVelocity;
         private bool isMessageReceived;
+        public GameObject assignedObject;
 
 		protected override void Start()
 		{
@@ -53,14 +57,14 @@ namespace RosSharp.RosBridgeClient
         {
             float deltaTime = Time.realtimeSinceStartup-previousRealTime;
 
-            transform.Translate(linearVelocity * deltaTime);
-            transform.Rotate(Vector3.forward, angularVelocity.x * deltaTime);
-            transform.Rotate(Vector3.up, angularVelocity.y * deltaTime);
-            transform.Rotate(Vector3.left, angularVelocity.z * deltaTime);
+            assignedObject.transform.Translate(linearVelocity * deltaTime);
+            assignedObject.transform.Rotate(Vector3.forward, angularVelocity.x * deltaTime);
+            assignedObject.transform.Rotate(Vector3.up, angularVelocity.y * deltaTime);
+            assignedObject.transform.Rotate(Vector3.left, angularVelocity.z * deltaTime);
 
             previousRealTime = Time.realtimeSinceStartup;
 
             isMessageReceived = false;
-        }     
+        }
     }
 }


### PR DESCRIPTION
This is a proposed fix for #113 .

However, I am not sure if this is the best way to solve it. It follows the OdometrySubscriber but introduces an inconsistency: The PoseStampedPublisher binds to a Transform, while the PoseStampedSubscriber now uses a GameObject (but could easily be changed to also use a Transform – or vice versa).

Maybe a better solution is to either use specific components for all publishers and subscribers (e.g. the ImagePublisher and ImageSubscriber use a Camera and a MeshRenderer, respectively) or use GameObjects whenever possible – maybe even adding `assignedObject` to the Publisher/Subscriber abstract classes.

What do you think?