### PR TITLE
Problem with timestamp cast to uint

### DIFF
--- a/Unity3D/Assets/RosSharp/Scripts/RosBridgeClient/Timing/Timer.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/RosBridgeClient/Timing/Timer.cs
@@ -44,7 +44,7 @@ namespace RosSharp.RosBridgeClient
         private static void Now(out uint secs, out uint nsecs)
         {
             TimeSpan timeSpan = DateTime.Now.ToUniversalTime() - UNIX_EPOCH;
-            double msecs = (uint)timeSpan.TotalMilliseconds;
+            double msecs = timeSpan.TotalMilliseconds;
             secs = (uint)(msecs / 1000);
             nsecs = (uint)((msecs / 1000 - secs) * 1e+9);
         }


### PR DESCRIPTION
Casting timeSpan.TotalMilliseconds to uint will truncate the timestamp. As secs and nsecs are casted to uint later anyway, removing the cast seems to be the way to go.