### PR TITLE
Swap min/max limits and negate to match sign

### DIFF
--- a/Unity3D/Assets/RosSharp/Scripts/Urdf/JointLimitsManagers/HingeJointLimitsManager.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/Urdf/JointLimitsManagers/HingeJointLimitsManager.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 © Siemens AG, 2017-2018
 Author: Dr. Martin Bischoff (martin.bischoff@siemens.com)
 
@@ -158,8 +158,8 @@ namespace RosSharp
 
         public void InitializeLimits(Urdf.Joint.Limit limit, HingeJoint joint)
         {
-            LargeAngleLimitMin = (float)limit.lower * Mathf.Rad2Deg;
-            LargeAngleLimitMax = (float)limit.upper * Mathf.Rad2Deg;
+            LargeAngleLimitMin = (float)limit.upper * -1.0f * Mathf.Rad2Deg;
+            LargeAngleLimitMax = (float)limit.lower * -1.0f * Mathf.Rad2Deg;
 
             _hingeJoint = joint;
 

--- a/Unity3D/Assets/RosSharp/Scripts/Urdf/UrdfComponents/UrdfJoints/UrdfJointRevolute.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/Urdf/UrdfComponents/UrdfJoints/UrdfJointRevolute.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 © Siemens AG, 2018-2019
 Author: Suzannah Smith (suzannah.smith@siemens.com)
 
@@ -90,8 +90,8 @@ namespace RosSharp.Urdf
         {
             HingeJointLimitsManager hingeJointLimits = GetComponent<HingeJointLimitsManager>();
             return new Joint.Limit(
-                Math.Round(hingeJointLimits.LargeAngleLimitMin * Mathf.Deg2Rad, RoundDigits),
-                Math.Round(hingeJointLimits.LargeAngleLimitMax * Mathf.Deg2Rad, RoundDigits),
+                Math.Round(hingeJointLimits.LargeAngleLimitMax * -1.0f * Mathf.Deg2Rad, RoundDigits),
+                Math.Round(hingeJointLimits.LargeAngleLimitMin * -1.0f * Mathf.Deg2Rad, RoundDigits),
                 EffortLimit,
                 VelocityLimit);
         }


### PR DESCRIPTION
As far as my understanding of the URDF right-hand Z-Up to the Unity left-hand Y-Up coordinate system goes, the value of the angle is negated.

This PR updates the limit import/export to flip min/max and negate them.