### PR TITLE
Remove STL prefab if already exists to avoid caching issues

### DIFF
--- a/Unity3D/Assets/RosSharp/Scripts/Urdf/Editor/MeshProcessing/StlAssetPostProcessor.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/Urdf/Editor/MeshProcessing/StlAssetPostProcessor.cs
@@ -32,6 +32,13 @@ namespace RosSharp
 
         private static void createStlPrefab(string stlFile)
         {
+            string prefabPath = getPrefabAssetPath(stlFile);
+            if(!string.IsNullOrEmpty(AssetDatabase.AssetPathToGUID(prefabPath)))
+            {
+                AssetDatabase.DeleteAsset(prefabPath);
+            }
+
+
             GameObject gameObject = CreateStlParent(stlFile);
             if (gameObject == null)
                 return;
@@ -51,6 +58,12 @@ namespace RosSharp
             for (int i = 0; i < meshes.Length; i++)
             {
                 string meshAssetPath = getMeshAssetPath(stlFile, i);
+                if(!string.IsNullOrEmpty(AssetDatabase.AssetPathToGUID(meshAssetPath)))
+                {
+                    AssetDatabase.DeleteAsset(meshAssetPath);
+                }
+
+
                 AssetDatabase.CreateAsset(meshes[i], meshAssetPath);
                 GameObject gameObject = CreateStlGameObject(meshAssetPath, material);
                 gameObject.transform.SetParent(parent.transform, false);


### PR DESCRIPTION
This PR adds a check to the STL post processor to remove the prefab/meshes from the asset database before import.

This solves an issue with the link between the mesh in the scene and the mesh saved in the asset database being lost when changing the STL and then reimporting the robot. That makes it impossible to save the resulting robot as prefab without losing the meshes.

A disadvantage of this PR would be that if the prefab is used outside a full robot, that link will be broken.