### PR TITLE
Removed validate flag on DLL's to fix issue #300

### DIFF
--- a/Unity3D/Assets/RosSharp/Plugins/MessageGeneration.dll.meta
+++ b/Unity3D/Assets/RosSharp/Plugins/MessageGeneration.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: e0098a5245e6d6e5f8f39f0fc5f0ad8d
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity3D/Assets/RosSharp/Plugins/Microsoft/System.Text.Encodings.Web.dll.meta
+++ b/Unity3D/Assets/RosSharp/Plugins/Microsoft/System.Text.Encodings.Web.dll.meta
@@ -9,8 +9,18 @@ PluginImporter:
   isPreloaded: 0
   isOverridable: 0
   isExplicitlyReferenced: 0
-  validateReferences: 1
+  validateReferences: 0
   platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 0
+        Exclude Win: 0
+        Exclude Win64: 0
   - first:
       Any: 
     second:
@@ -19,9 +29,35 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 1
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
   - first:
       Windows Store Apps: WindowsStoreApps
     second:

--- a/Unity3D/Assets/RosSharp/Plugins/Microsoft/System.Text.Json.dll.meta
+++ b/Unity3D/Assets/RosSharp/Plugins/Microsoft/System.Text.Json.dll.meta
@@ -9,8 +9,18 @@ PluginImporter:
   isPreloaded: 0
   isOverridable: 0
   isExplicitlyReferenced: 0
-  validateReferences: 1
+  validateReferences: 0
   platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 0
+        Exclude Win: 0
+        Exclude Win64: 0
   - first:
       Any: 
     second:
@@ -19,9 +29,35 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 1
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
   - first:
       Windows Store Apps: WindowsStoreApps
     second:

--- a/Unity3D/Assets/RosSharp/Plugins/RosBridgeClient.dll.meta
+++ b/Unity3D/Assets/RosSharp/Plugins/RosBridgeClient.dll.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6309cb9896eea544d98d578a6b096eeb
+guid: 9acd399b10a19bc8e9d4185bdd4192db
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Unity3D/Assets/RosSharp/Plugins/Urdf.dll.meta
+++ b/Unity3D/Assets/RosSharp/Plugins/Urdf.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 541e87a9919855ed0b0c50161bfbf749
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity3D/Assets/RosSharp/Scripts/Urdf/Resources.meta
+++ b/Unity3D/Assets/RosSharp/Scripts/Urdf/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7276cac625620e51fa750931d921bf54
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR is a fix for https://github.com/siemens/ros-sharp/issues/300

It solves the strict version error in the DLL's in Unity 2020.