### PR TITLE
Add inertiaTensor to the custom Rigidbody editor only if freezeRotation is disabled.

### DIFF
--- a/Unity3D/Assets/RosSharp/Scripts/Urdf/Editor/CustomEditors/RigidbodyEditor.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/Urdf/Editor/CustomEditors/RigidbodyEditor.cs
@@ -29,8 +29,11 @@ namespace RosSharp.Urdf.Editor
 
             Rigidbody _rigidbody = (Rigidbody)target;
             _rigidbody.centerOfMass = EditorGUILayout.Vector3Field("Center Of Mass", _rigidbody.centerOfMass);
-            _rigidbody.inertiaTensor = EditorGUILayout.Vector3Field("Inertia Tensor", _rigidbody.inertiaTensor);
-
+            if (!_rigidbody.freezeRotation)
+            {
+                _rigidbody.inertiaTensor = EditorGUILayout.Vector3Field("Inertia Tensor", _rigidbody.inertiaTensor);
+            }
+            
             Quaternion inertiaTensorRotation = new Quaternion();
             inertiaTensorRotation.eulerAngles = EditorGUILayout.Vector3Field("Inertia Tensor Rotation", _rigidbody.inertiaTensorRotation.eulerAngles);
             _rigidbody.inertiaTensorRotation = inertiaTensorRotation;

--- a/Unity3D/Assets/RosSharp/Scripts/Urdf/Editor/CustomEditors/RigidbodyEditor.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/Urdf/Editor/CustomEditors/RigidbodyEditor.cs
@@ -29,11 +29,11 @@ namespace RosSharp.Urdf.Editor
 
             Rigidbody _rigidbody = (Rigidbody)target;
             _rigidbody.centerOfMass = EditorGUILayout.Vector3Field("Center Of Mass", _rigidbody.centerOfMass);
-            if (!_rigidbody.freezeRotation)
+            if (_rigidbody.constraints <= RigidbodyConstraints.FreezePosition)
             {
                 _rigidbody.inertiaTensor = EditorGUILayout.Vector3Field("Inertia Tensor", _rigidbody.inertiaTensor);
             }
-            
+
             Quaternion inertiaTensorRotation = new Quaternion();
             inertiaTensorRotation.eulerAngles = EditorGUILayout.Vector3Field("Inertia Tensor Rotation", _rigidbody.inertiaTensorRotation.eulerAngles);
             _rigidbody.inertiaTensorRotation = inertiaTensorRotation;


### PR DESCRIPTION
Enabling rotational constraints on objects results in the following error:
`Inertia tensor must be larger than zero in all coordinates.`

In my particular use case these objects were created from Unity. Setting rotational constraint would make the inertial tensor to be a zero vector which for some reason doesn't create a problem in projects that do not use ROS#.