### PR TITLE
[Bug Fix - #361] Improper radians to degrees conversion in LaserScanReader.cs

### DIFF
--- a/Unity3D/Assets/RosSharp/Scripts/RosBridgeClient/MessageHandling/LaserScanReader.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/RosBridgeClient/MessageHandling/LaserScanReader.cs
@@ -65,7 +65,7 @@ namespace RosSharp.RosBridgeClient
 
             for (int i = 0; i < samples; i++)
             {
-                rays[i] = new Ray(transform.position, Quaternion.Euler(new Vector3(0, angle_min - angle_increment * i * 180 / Mathf.PI, 0)) * transform.forward);
+                rays[i] = new Ray(transform.position, GetRayRotation(i) * transform.forward);
                 directions[i] = Quaternion.Euler(-transform.rotation.eulerAngles) * rays[i].direction;
 
                 raycastHits[i] = new RaycastHit();
@@ -73,6 +73,13 @@ namespace RosSharp.RosBridgeClient
                     if (raycastHits[i].distance >= range_min && raycastHits[i].distance <= range_max)
                         ranges[i] = raycastHits[i].distance;
             }
+        }
+
+        private Quaternion GetRayRotation(int sample) {
+            float eulerAngleInRadians = angle_min + (angle_increment * sample);
+            float eulerAngleInDegrees = eulerAngleInRadians * 180 / Mathf.PI;
+
+            return Quaternion.Euler(new Vector3(0, eulerAngleInDegrees, 0));
         }
     }
 }


### PR DESCRIPTION
**Description**

Fixed the issue (#361) in _LaserScanReader.cs_ that was causing _improper radians to degrees conversion_.


**Screenshots**

<img width="1437" alt="Screen Shot 2020-12-02 at 02 14 34" src="https://user-images.githubusercontent.com/18555817/100816473-67471980-3446-11eb-88d3-51f44b1caf9d.png">


**Test parameters**

angle_min=-3.14
sample=360
angle_increment=0.01745329
angle_max=0.01745329


**Observed results before the fix (As written in #361)**

Read the output `angle_min - angle_increment * i * 180 / Mathf.PI` calculation and you'll see instead that it starts from -3.14 degrees.

Another sanity check, using the values listed above. An object directly infront of the laserScanReader you would expect values in the middle of the `Ranges[]` output. While currently you would find them are the beginning/end of the `Range[]` array.


**Expected results before the fix (As written in #361)**

We should expect laserScanReader to start from -3.14 (-180) and iterate through to 3.14(180)


**Observed results after the fix**

As can be seen in the screenshot above, laserScanReader starts from -180 degrees and iterates through to 180 degrees.


 