### PR TITLE
Added optional shader override in ImageSubscriber

### DIFF
--- a/Unity3D/Assets/RosSharp/Scripts/RosBridgeClient/RosCommuncation/ImageSubscriber.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/RosBridgeClient/RosCommuncation/ImageSubscriber.cs
@@ -21,16 +21,20 @@ namespace RosSharp.RosBridgeClient
     public class ImageSubscriber : UnitySubscriber<MessageTypes.Sensor.CompressedImage>
     {
         public MeshRenderer meshRenderer;
-
+	public bool overrideImageMaterial = false;
+	
         private Texture2D texture2D;
         private byte[] imageData;
         private bool isMessageReceived;
 
         protected override void Start()
         {
-			base.Start();
-            texture2D = new Texture2D(1, 1);
-            meshRenderer.material = new Material(Shader.Find("Standard"));
+	    base.Start();
+            texture2D = new Texture2D(1, 1);            
+	    if(overrideImageMaterial)
+	    {
+	    	meshRenderer.material = new Material(Shader.Find("Standard"));
+	    }
         }
         private void Update()
         {


### PR DESCRIPTION
Sometimes could be useful to set up a shader different from the standard material, i've added a flag to enable the material override in the image subscriber.