### PR TITLE
Correct angular velocity calculation in TwistSubscriber

### DIFF
--- a/Unity3D/Assets/RosSharp/Scripts/RosBridgeClient/RosCommuncation/TwistSubscriber.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/RosBridgeClient/RosCommuncation/TwistSubscriber.cs
@@ -57,9 +57,9 @@ namespace RosSharp.RosBridgeClient
             float deltaTime = Time.realtimeSinceStartup - previousRealTime;
 
             SubscribedTransform.Translate(linearVelocity * deltaTime);
-            SubscribedTransform.Rotate(Vector3.forward, angularVelocity.x * deltaTime);
-            SubscribedTransform.Rotate(Vector3.up, angularVelocity.y * deltaTime);
-            SubscribedTransform.Rotate(Vector3.left, angularVelocity.z * deltaTime);
+            SubscribedTransform.Rotate(Vector3.forward, angularVelocity.x * Mathf.Rad2Deg * deltaTime);
+            SubscribedTransform.Rotate(Vector3.up, angularVelocity.y * Mathf.Rad2Deg * deltaTime);
+            SubscribedTransform.Rotate(Vector3.left, angularVelocity.z * Mathf.Rad2Deg * deltaTime);
 
             isMessageReceived = false;
         }


### PR DESCRIPTION
Twist messages in ROS represent angles in radian system[1], while Unity's Transform uses angle values. Modify the TwistSubscriber so that Unity correctly recognizes and transforms angle messages published from ROS.

[1] http://wiki.ros.org/tf2/Tutorials/Quaternions