### PR TITLE
Fix the problem that the laser data is mirrored in ROS

### DIFF
--- a/Unity3D/Assets/RosSharp/Scripts/RosBridgeClient/MessageHandling/LaserScanReader.cs
+++ b/Unity3D/Assets/RosSharp/Scripts/RosBridgeClient/MessageHandling/LaserScanReader.cs
@@ -23,6 +23,7 @@ namespace RosSharp.RosBridgeClient
         private RaycastHit[] raycastHits;
         private Vector3[] directions;
         private LaserScanVisualizer[] laserScanVisualizers;
+        private float[] rangesReversed;
 
         public int samples = 360;
         public int update_rate = 1800;
@@ -40,6 +41,7 @@ namespace RosSharp.RosBridgeClient
         {
             directions = new Vector3[samples];
             ranges = new float[samples];
+            rangesReversed = new float[samples];
             intensities = new float[samples];
             rays = new Ray[samples];
             raycastHits = new RaycastHit[samples];
@@ -54,7 +56,7 @@ namespace RosSharp.RosBridgeClient
                 foreach (LaserScanVisualizer laserScanVisualizer in laserScanVisualizers)
                     laserScanVisualizer.SetSensorData(gameObject.transform, directions, ranges, range_min, range_max);
 
-            return ranges;
+            return rangesReversed;
         }
 
         private void MeasureDistance()
@@ -72,12 +74,15 @@ namespace RosSharp.RosBridgeClient
                 if (Physics.Raycast(rays[i], out raycastHits[i], range_max))
                     if (raycastHits[i].distance >= range_min && raycastHits[i].distance <= range_max)
                         ranges[i] = raycastHits[i].distance;
+
+                rangesReversed[samples - i - 1] = ranges[i];
             }
         }
 
-        private Quaternion GetRayRotation(int sample) {
+        private Quaternion GetRayRotation(int sample)
+        {
             float eulerAngleInRadians = angle_min + (angle_increment * sample);
-            float eulerAngleInDegrees = eulerAngleInRadians * 180 / Mathf.PI;
+            float eulerAngleInDegrees = eulerAngleInRadians * Mathf.Rad2Deg;
 
             return Quaternion.Euler(new Vector3(0, eulerAngleInDegrees, 0));
         }


### PR DESCRIPTION
Recently I am testing gmapping with ROS#. I imported the urdf of my robot, set up the navigation stack, and found everything is working fine except the LaserScanReader.

As is shown in the images below, the laser scan data is mirrored in RViz. The obstacles should be on the right side of the robot, not on the left.

![image](https://user-images.githubusercontent.com/22185413/156689808-db6cb9b8-a8d1-4ae4-aa95-2e3014d2c40d.png)
![image](https://user-images.githubusercontent.com/22185413/156689952-add25954-c931-4f10-b196-725e67c32c37.png)

After doing some debugging work, I found that this problem is caused by the fact that ROS# does not align the laser data in the same way as ROS. ROS requires that laser scan angles are measured counterclockwise[1], with 0 facing forward, but ROS# uses the clockwise alignment in Unity.

I fixed the problem in this commit. The reason for keeping the old range array is that Laser Scan Visualizer in ROS# may need the data arranged in a clockwise way.

btw, this may help solve issue #199 

[1] http://wiki.ros.org/navigation/Tutorials/RobotSetup/Sensors

