### PR TITLE
Editor script assembly definition only included in editor

### DIFF
--- a/com.siemens.ros-sharp/Editor/siemens.ros-sharp.Editor.asmdef
+++ b/com.siemens.ros-sharp/Editor/siemens.ros-sharp.Editor.asmdef
@@ -4,7 +4,9 @@
     "references": [
         "siemens.ros-sharp.Runtime"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
Allow building an app when the framework is added through git using the package manager. Not much changes, not much additional info required IMO and I'm always available if more info is required :)