### PR TITLE
fix: fix wrong file name when trying to create a robot from the urdf when using ROS urdf import feature

### DIFF
--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/UrdfTransfer/TransferFromRosHandler.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/UrdfTransfer/TransferFromRosHandler.cs
@@ -42,6 +42,7 @@ namespace RosSharp.RosBridgeClient
         private string assetPath;
         private string urdfParameter;
         private string robotNameParameter; 
+        private string urdfFileName;
 
         private RosSocket rosSocket;
         public RosConnector rosConnector;
@@ -91,6 +92,7 @@ namespace RosSharp.RosBridgeClient
             StatusEvents["resourceFilesReceived"] = urdfTransfer.Status["resourceFilesReceived"];
 
             urdfTransfer.Transfer();
+            urdfFileName = urdfTransfer.UrdfFileName;
 
             if (StatusEvents["robotNameReceived"].WaitOne(timeout * 1000))
             {
@@ -119,9 +121,7 @@ namespace RosSharp.RosBridgeClient
                 "Do you want to generate a " + robotName + " GameObject now?",
                 "Yes", "No"))
             {
-                Urdf.Editor.UrdfRobotExtensions.Create(Path.Combine(
-                    localDirectory,
-                    Path.GetFileNameWithoutExtension(urdfParameter) + ".urdf"));
+                Urdf.Editor.UrdfRobotExtensions.Create(Path.Combine(localDirectory, urdfFileName));
             }
 
             StatusEvents["importComplete"].Set();

--- a/com.siemens.ros-sharp/Runtime/Libraries/RosBridgeClient/UrdfTransfer/UrdfTransferFromRos.cs
+++ b/com.siemens.ros-sharp/Runtime/Libraries/RosBridgeClient/UrdfTransfer/UrdfTransferFromRos.cs
@@ -44,6 +44,9 @@ namespace RosSharp.RosBridgeClient.UrdfTransfer
         private string urdfParameter;
         private string robotNameParameter;
 
+        private string urdfFileName;
+        public string UrdfFileName { get => urdfFileName; }
+
         public string LocalUrdfDirectory
         {
             get
@@ -76,10 +79,10 @@ namespace RosSharp.RosBridgeClient.UrdfTransfer
             RosSocket.CallService<rosapi.GetParamRequest, rosapi.GetParamResponse>("/rosapi/get_param",
                                                                                     ReceiveRobotName,
                                                                                     new rosapi.GetParamRequest(robotNameParameter, CutAfterColon(robotNameParameter)));
-
+            urdfFileName = CutAfterColon(urdfParameter) + ".urdf";
             var robotDescriptionReceiver = new ServiceReceiver<rosapi.GetParamRequest, rosapi.GetParamResponse>(RosSocket, "/rosapi/get_param",
                                                                                         new rosapi.GetParamRequest(urdfParameter, DEFAULT_STRING),
-                                                                                        Path.DirectorySeparatorChar + CutAfterColon(urdfParameter) + ".urdf");
+                                                                                        Path.DirectorySeparatorChar + urdfFileName);
 
             robotDescriptionReceiver.ReceiveEventHandler += ReceiveRobotDescription;
         }


### PR DESCRIPTION
- In TransferFromRosHandler, the file name was using robot_state_publisher:robot_description.urdf instead of the name that was defined in the class UrdfTransferFromRos (robot_description.urdf)