### PR TITLE
fix build error with ament_index_cpp not being found

### DIFF
--- a/ROS Packages/ROS2/file_server2/CMakeLists.txt
+++ b/ROS Packages/ROS2/file_server2/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(file_server2_node src/file_server.cpp)
 ament_target_dependencies(file_server2_node
   rclcpp
   std_msgs
+  ament_index_cpp
 )
 
 # Get the typesupport targets


### PR DESCRIPTION
There was an error when building the file_server2 package initially The CMakeLists.txt for file_server2 package was missing ament_index_cpp insde the ament_target_dependencies, which has now been fixed