### PR TITLE
fixes for issues when building

### DIFF
--- a/com.siemens.ros-sharp/Editor/siemens.ros-sharp.Editor.asmdef
+++ b/com.siemens.ros-sharp/Editor/siemens.ros-sharp.Editor.asmdef
@@ -4,7 +4,7 @@
     "references": [
         "siemens.ros-sharp.Runtime"
     ],
-    "includePlatforms": [],
+    "includePlatforms": ["Editor"],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/com.siemens.ros-sharp/Runtime/RosBridgeClient/RosCommunication/StringSubscriber.cs
+++ b/com.siemens.ros-sharp/Runtime/RosBridgeClient/RosCommunication/StringSubscriber.cs
@@ -14,7 +14,6 @@ limitations under the License.
 */
 
 using UnityEngine;
-using UnityEditor;
 
 namespace RosSharp.RosBridgeClient
 {

--- a/com.siemens.ros-sharp/Runtime/RosBridgeClient/RosCommunication/UnityFibonacciActionSever.cs
+++ b/com.siemens.ros-sharp/Runtime/RosBridgeClient/RosCommunication/UnityFibonacciActionSever.cs
@@ -18,7 +18,9 @@ limitations under the License.
 */
 
 using UnityEngine;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 
 namespace RosSharp.RosBridgeClient.Actionlib
 {
@@ -57,6 +59,7 @@ namespace RosSharp.RosBridgeClient.Actionlib
 
     public class ReadOnlyAttribute : PropertyAttribute { }
 
+#if UNITY_EDITOR
     [CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
     public class ReadOnlyDrawer : PropertyDrawer
     {
@@ -67,4 +70,5 @@ namespace RosSharp.RosBridgeClient.Actionlib
             GUI.enabled = true;
         }
     }
+#endif    
 }


### PR DESCRIPTION
Fixes #475 
(Error during build 'Cannot build player while editor is importing assets or compiling scripts)

Editor must be listed as a platform in the asmdef file. 
Runtime code can not refer to UntiyEditor