### PR TITLE
fix: Add UNITY_EDITOR preprocessor directives to editor scripts

### DIFF
--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/FibonacciAction/FibonacciActionClientEditor.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/FibonacciAction/FibonacciActionClientEditor.cs
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEditor;
 using UnityEngine;
 
@@ -38,3 +40,5 @@ namespace RosSharp.RosBridgeClient.Actionlib
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/JointStatePatcherEditor.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/JointStatePatcherEditor.cs
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEngine;
 using UnityEditor;
 
@@ -54,3 +56,5 @@ namespace RosSharp.RosBridgeClient
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/DirectoryActionAutoGenEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/DirectoryActionAutoGenEditorWindow.cs
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -31,8 +33,6 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
             get { return "action"; }
         }
 
-
-
         [MenuItem("RosBridgeClient/Auto Generate Actions/All Actions in directory...", false, 22)]
         private static void OpenWindow()
         {
@@ -50,3 +50,5 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
 
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/DirectoryAutoGenEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/DirectoryAutoGenEditorWindow.cs
@@ -11,6 +11,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
@@ -160,3 +163,5 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
         protected abstract List<string> Generate(string inPath, string outPath, bool isRos2, string rosPackageName = "");
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/DirectoryMsgAutoGenEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/DirectoryMsgAutoGenEditorWindow.cs
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -48,3 +50,5 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
 
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/DirectorySrvAutoGenEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/DirectorySrvAutoGenEditorWindow.cs
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -32,7 +34,6 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
             get { return "srv"; }
         }
 
-
         [MenuItem("RosBridgeClient/Auto Generate Services/All Services in directory...", false, 12)]
         private static void OpenWindow()
         {
@@ -50,3 +51,5 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
 
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/PackageActionAutoGenEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/PackageActionAutoGenEditorWindow.cs
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -48,3 +50,4 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
     }
 }
 
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/PackageAutoGenEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/PackageAutoGenEditorWindow.cs
@@ -12,6 +12,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -171,3 +173,5 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
         protected abstract List<string> Generate(string inPath, string outPath, bool isRos2, string rosPackageName = "");
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/PackageMsgAutoGenEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/PackageMsgAutoGenEditorWindow.cs
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using RosSharp.RosBridgeClient.MessageGeneration;
 using UnityEditor;
@@ -48,3 +50,5 @@ namespace RosSharp.RosBridgeClient
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/PackageSrvAutoGenEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/PackageSrvAutoGenEditorWindow.cs
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -47,3 +49,5 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/SingleActionAutoGenEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/SingleActionAutoGenEditorWindow.cs
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -30,7 +32,6 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
         {
             get { return "action"; }
         }
-
 
         [MenuItem("RosBridgeClient/Auto Generate Actions/Single Action...", false, 20)]
         private static void OpenWindow()
@@ -50,3 +51,5 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
 
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/SingleAutoGenEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/SingleAutoGenEditorWindow.cs
@@ -12,6 +12,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
@@ -128,3 +130,5 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
         protected abstract List<string> Generate(string inPath, string outPath, bool isRos2, string rosPackageName = "");
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/SingleMsgAutoGenEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/SingleMsgAutoGenEditorWindow.cs
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -31,7 +33,6 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
             get { return "msg"; }
         }
 
-
         [MenuItem("RosBridgeClient/Auto Generate Messages/Single Message...", false, 0)]
         private static void OpenWindow()
         {
@@ -49,3 +50,5 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
 
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/SingleSrvAutoGenEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/MessageGeneration/SingleSrvAutoGenEditorWindow.cs
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -33,7 +35,6 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
             get { return "srv"; }
         }
 
-
         [MenuItem("RosBridgeClient/Auto Generate Services/Single Service...", false, 10)]
         public static void OpenWindow()
         {
@@ -51,3 +52,5 @@ namespace RosSharp.RosBridgeClient.MessageGeneration
 
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/RosConnectorEditor.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/RosConnectorEditor.cs
@@ -1,4 +1,7 @@
+#if UNITY_EDITOR
+
 using UnityEditor;
+using UnityEditor.Build;
 using UnityEngine;
 
 namespace RosSharp.RosBridgeClient
@@ -34,7 +37,7 @@ namespace RosSharp.RosBridgeClient
             string defineSymbolROS2 = "ROS2"; 
 
             BuildTargetGroup targetGroup = EditorUserBuildSettings.selectedBuildTargetGroup;
-            string defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(targetGroup);
+            string defines = PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(targetGroup));
 
             // Remove ROS2 define symbol
             defines = defines.Replace($"{defineSymbolROS2};", "").Replace(defineSymbolROS2, "");
@@ -47,7 +50,7 @@ namespace RosSharp.RosBridgeClient
             }
 
             // Set scripting define symbols
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(targetGroup, defines);
+            PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(targetGroup), defines);
 
             // Execute Assembly Builder
             AssetDatabase.Refresh();
@@ -62,3 +65,5 @@ namespace RosSharp.RosBridgeClient
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/UrdfTransfer/TransferFromRosEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/UrdfTransfer/TransferFromRosEditorWindow.cs
@@ -23,6 +23,8 @@ limitations under the License.
     (C) Siemens AG, 2024, Mehmet Emre Cakal (emre.cakal@siemens.com/m.emrecakal@gmail.com)
 */
 
+#if UNITY_EDITOR
+
 using System.IO;
 using System.Threading;
 using UnityEngine;
@@ -132,6 +134,8 @@ namespace RosSharp.RosBridgeClient
             EditorGUILayout.LabelField(label, state ? "done" : "open", guiStyle);
         }
 
+#if UNITY_EDITOR
+
         private void OnInspectorUpdate()
         {
             Repaint();
@@ -140,6 +144,8 @@ namespace RosSharp.RosBridgeClient
             // We check the status to call the methods at the right step in the process:
             transferHandler.GenerateModelIfReady();
         }
+
+#endif
 
         #region EditorPrefs
 
@@ -226,3 +232,5 @@ namespace RosSharp.RosBridgeClient
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/UrdfTransfer/TransferFromRosHandler.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/UrdfTransfer/TransferFromRosHandler.cs
@@ -107,6 +107,8 @@ namespace RosSharp.RosBridgeClient
             rosSocket.Close();
         }
 
+#if UNITY_EDITOR
+
         public void GenerateModelIfReady()
         {
             if (!StatusEvents["resourceFilesReceived"].WaitOne(0) || StatusEvents["importComplete"].WaitOne(0))
@@ -127,8 +129,10 @@ namespace RosSharp.RosBridgeClient
             StatusEvents["importComplete"].Set();
         }
 
+#endif
+
         public bool CheckForRosConnector() {
-            rosConnector = GameObject.FindObjectOfType(typeof(RosConnector)) as RosConnector;
+            rosConnector = GameObject.FindFirstObjectByType(typeof(RosConnector)) as RosConnector;
             return rosConnector != null;    
         }
 

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/UrdfTransfer/TransferToRosEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/UrdfTransfer/TransferToRosEditorWindow.cs
@@ -23,6 +23,8 @@ limitations under the License.
     (C) Siemens AG, 2024, Mehmet Emre Cakal (emre.cakal@siemens.com/m.emrecakal@gmail.com)
 */
 
+#if UNITY_EDITOR
+
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -216,3 +218,5 @@ namespace RosSharp.RosBridgeClient
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/RosBridgeClient/UrdfTransfer/TransferToRosHandler.cs
+++ b/com.siemens.ros-sharp/Editor/RosBridgeClient/UrdfTransfer/TransferToRosHandler.cs
@@ -111,7 +111,7 @@ namespace RosSharp.RosBridgeClient
         /// </summary>
         /// <returns><c>true</c> if a RosConnector component exists; otherwise, <c>false</c>.</returns>
         public bool CheckForRosConnector() {
-            rosConnector = GameObject.FindObjectOfType(typeof(RosConnector)) as RosConnector;
+            rosConnector = GameObject.FindFirstObjectByType(typeof(RosConnector)) as RosConnector;
             return rosConnector != null;
         }
 

--- a/com.siemens.ros-sharp/Editor/Urdf/AssetHandlers/LocateAssetHandler.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/AssetHandlers/LocateAssetHandler.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.IO;
 using System;
 using UnityEngine;
@@ -109,3 +111,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/AssetHandlers/UrdfAssetPathHandler.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/AssetHandlers/UrdfAssetPathHandler.cs
@@ -14,6 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+#if UNITY_EDITOR
+
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -106,3 +109,5 @@ namespace RosSharp.Urdf.Editor
     }
 
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/AssetHandlers/UrdfMeshExportHandler.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/AssetHandlers/UrdfMeshExportHandler.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -115,3 +117,5 @@ namespace RosSharp.Urdf.Editor
         } 
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/HingeJointLimitsManagerEditor.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/HingeJointLimitsManagerEditor.cs
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEditor;
 using UnityEngine;
 
@@ -70,3 +72,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfCollisionEditor.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfCollisionEditor.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEditor;
 using UnityEngine;
 
@@ -70,3 +72,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfCollisionsEditor.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfCollisionsEditor.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEditor;
 using UnityEngine;
 
@@ -38,3 +40,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfInertialEditor.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfInertialEditor.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEditor;
 using UnityEngine;
 
@@ -69,3 +71,5 @@ namespace RosSharp.Urdf.Editor
 
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfJointEditor.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfJointEditor.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEditor;
 using UnityEngine;
 
@@ -124,3 +126,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfLinkEditor.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfLinkEditor.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEditor;
 using UnityEngine;
 
@@ -50,3 +52,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfPluginsEditor.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfPluginsEditor.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEditor;
 using UnityEngine;
 
@@ -36,3 +38,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfRobotEditor.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfRobotEditor.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEditor;
 using UnityEngine;
 
@@ -82,3 +84,5 @@ namespace RosSharp.Urdf.Editor
 
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfVisualEditor.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfVisualEditor.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEditor;
 using UnityEngine;
 
@@ -69,3 +71,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfVisualsEditor.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/CustomInspectors/UrdfVisualsEditor.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEditor;
 using UnityEngine;
 
@@ -43,3 +45,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/MenuItems/UrdfExportEditorWindow.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/MenuItems/UrdfExportEditorWindow.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -134,3 +136,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/MenuItems/UrdfImporterContextMenuItem.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/MenuItems/UrdfImporterContextMenuItem.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.IO;
 using UnityEditor;
 
@@ -36,3 +38,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/MenuItems/UrdfImporterMenuItem.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/MenuItems/UrdfImporterMenuItem.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -36,3 +38,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/MenuItems/UrdfRobotCreatorMenuItem.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/MenuItems/UrdfRobotCreatorMenuItem.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEditor;
 
 namespace RosSharp.Urdf.Editor
@@ -28,3 +30,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/MeshProcessing/ColladaAssetPostProcessor.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/MeshProcessing/ColladaAssetPostProcessor.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.Xml.Linq;
 using System.Globalization;
 using UnityEditor;
@@ -111,3 +113,5 @@ namespace RosSharp
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/MeshProcessing/StlAssetPostProcessor.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/MeshProcessing/StlAssetPostProcessor.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEngine;
 using UnityEditor;
 using System.Linq;
@@ -74,3 +76,5 @@ namespace RosSharp
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfCollisionExtensions.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfCollisionExtensions.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEngine;
 
 namespace RosSharp.Urdf.Editor
@@ -69,3 +71,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfCollisionsExtensions.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfCollisionsExtensions.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -46,3 +48,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfGeometry.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfGeometry.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System;
 using UnityEngine;
 
@@ -337,3 +339,5 @@ namespace RosSharp.Urdf.Editor
         #endregion
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfGeometryCollision.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfGeometryCollision.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEngine;
 using UnityEditor;
 
@@ -120,3 +122,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfGeometryVisual.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfGeometryVisual.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEngine;
 
 namespace RosSharp.Urdf.Editor
@@ -61,3 +63,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfLinkExtensions.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfLinkExtensions.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEngine;
 
 namespace RosSharp.Urdf.Editor
@@ -86,3 +88,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfMaterial.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfMaterial.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -191,3 +193,5 @@ namespace RosSharp.Urdf.Editor
         #endregion
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfRobotExtensions.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfRobotExtensions.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -123,3 +125,5 @@ namespace RosSharp.Urdf.Editor
         #endregion
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfVisualExtensions.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfVisualExtensions.cs
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if UNITY_EDITOR
+
 using UnityEngine;
 
 namespace RosSharp.Urdf.Editor
@@ -67,3 +69,5 @@ namespace RosSharp.Urdf.Editor
         }
     }
 }
+
+#endif

--- a/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfVisualsExtensions.cs
+++ b/com.siemens.ros-sharp/Editor/Urdf/UrdfComponents/UrdfVisualsExtensions.cs
@@ -14,6 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -47,3 +50,4 @@ namespace RosSharp.Urdf.Editor
     }
 }
 
+#endif

--- a/com.siemens.ros-sharp/Runtime/RosBridgeClient/RosCommunication/UnityFibonacciActionSever.cs
+++ b/com.siemens.ros-sharp/Runtime/RosBridgeClient/RosCommunication/UnityFibonacciActionSever.cs
@@ -57,6 +57,7 @@ namespace RosSharp.RosBridgeClient.Actionlib
 
     public class ReadOnlyAttribute : PropertyAttribute { }
 
+    #if UNITY_EDITOR
     [CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
     public class ReadOnlyDrawer : PropertyDrawer
     {
@@ -67,4 +68,5 @@ namespace RosSharp.RosBridgeClient.Actionlib
             GUI.enabled = true;
         }
     }
+    #endif
 }


### PR DESCRIPTION
The portions of code with Editor code were being compiled into the Android APK, which caused compilation errors.

I deactivated that portion of the code using the preprocessor directive `#if UNITY_EDITOR`.

This fixes #478.