### PR TITLE
[Feature] Add MapSubscriber & MapVisualizer

### DIFF
--- a/com.siemens.ros-sharp/Runtime/RosBridgeClient/RosCommunication/MapSubscriber.cs
+++ b/com.siemens.ros-sharp/Runtime/RosBridgeClient/RosCommunication/MapSubscriber.cs
@@ -1,0 +1,49 @@
+/*
+© Siemens AG, 2024
+Author: hoyadong1 (github.com/hoyadong1)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+<http://www.apache.org/licenses/LICENSE-2.0>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+using UnityEngine;
+
+namespace RosSharp.RosBridgeClient
+{
+    public class MapSubscriber : UnitySubscriber<MessageTypes.Nav.OccupancyGrid>
+    {
+        public sbyte[] mapData;
+        public int width;
+        public int height;
+        public float resolution;
+        public Vector3 originPosition;
+
+        public bool isMapReceived = false;
+
+        protected override void Start()
+        {
+            base.Start();
+        }
+
+        protected override void ReceiveMessage(MessageTypes.Nav.OccupancyGrid message)
+        {
+            width = (int)message.info.width;
+            height = (int)message.info.height;
+            resolution = message.info.resolution;
+            originPosition = new Vector3(
+                (float)message.info.origin.position.x,
+                (float)message.info.origin.position.y,
+                (float)message.info.origin.position.z
+            );
+
+            mapData = message.data;
+            isMapReceived = true;
+        }
+    }
+}

--- a/com.siemens.ros-sharp/Runtime/RosBridgeClient/SensorDataVisualization/MapVisualizer.cs
+++ b/com.siemens.ros-sharp/Runtime/RosBridgeClient/SensorDataVisualization/MapVisualizer.cs
@@ -1,0 +1,72 @@
+/*
+© Siemens AG, 2024
+Author: hoyadong1 (github.com/hoyadong1)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+<http://www.apache.org/licenses/LICENSE-2.0>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+using UnityEngine;
+using UnityEngine.UI;
+
+public class MapVisualizer : MonoBehaviour
+{
+    public GameObject rosBridge;
+    private RosSharp.RosBridgeClient.MapSubscriber mapSubscriber;
+    public RawImage rawImage;
+    private Texture2D mapTexture;
+
+    void Start()
+    {
+        if (rosBridge != null)
+        {
+            mapSubscriber = rosBridge.GetComponentInChildren<RosSharp.RosBridgeClient.MapSubscriber>();
+        }
+
+        if (mapSubscriber == null)
+        {
+            Debug.LogError("Could not find MapSubscriber. Check RosBridge object.");
+        }
+    }
+
+    void Update()
+    {
+        if (mapSubscriber != null && mapSubscriber.isMapReceived)
+        {
+            GenerateMapTexture();
+            mapSubscriber.isMapReceived = false;
+        }
+    }
+
+    private void GenerateMapTexture()
+    {
+        int width = mapSubscriber.width;
+        int height = mapSubscriber.height;
+        sbyte[] mapData = mapSubscriber.mapData;
+
+        if (mapTexture == null || mapTexture.width != width || mapTexture.height != height)
+        {
+            mapTexture = new Texture2D(width, height, TextureFormat.RGB24, false);
+        }
+
+        Color[] pixels = new Color[width * height];
+        for (int i = 0; i < mapData.Length; i++)
+        {
+            float value = mapData[i] == -1 ? 0.5f : mapData[i] / 100f;
+            pixels[i] = mapData[i] == -1
+                ? Color.gray
+                : Color.Lerp(Color.white, Color.black, value);
+        }
+
+        mapTexture.SetPixels(pixels);
+        mapTexture.Apply();
+
+        rawImage.texture = mapTexture;
+    }
+}


### PR DESCRIPTION
### 📌 What this PR does
- This PR introduces `MapSubscriber.cs`, which subscribes to ROS `OccupancyGrid` messages.
- It also includes `MapVisualizer.cs`, which renders the received map data as a `Texture2D` in Unity.
- The implementation supports real-time updates whenever new map data is received from ROS.

### 🚀 Why this is useful
- This feature allows users to visualize ROS-based navigation maps directly in Unity.
- It is particularly useful for applications involving SLAM, autonomous navigation, and robot simulation.

### 🙏 Additional Notes
As this is my first time contributing to this project, I sincerely appreciate any feedback or suggestions for improvement.  
If there are any issues or modifications required, I would be happy to make the necessary adjustments.  
Thank you for your time and for maintaining this valuable open-source project!