### PR TITLE
file_server security update

### DIFF
--- a/ROS Packages/ROS1/file_server/CMakeLists.txt
+++ b/ROS Packages/ROS1/file_server/CMakeLists.txt
@@ -188,5 +188,6 @@ include_directories(
 # catkin_add_nosetests(test)
 
 add_executable(file_server src/file_server.cpp)
-target_link_libraries(file_server ${catkin_LIBRARIES})
+target_compile_features(file_server PRIVATE cxx_std_17)
+target_link_libraries(file_server ${catkin_LIBRARIES} stdc++fs)
 add_dependencies(file_server file_server_gencpp)

--- a/ROS Packages/ROS1/file_server/launch/publish_description_turtlebot2.launch
+++ b/ROS Packages/ROS1/file_server/launch/publish_description_turtlebot2.launch
@@ -17,6 +17,8 @@ limitations under the License.
 
 	<include file="$(find file_server)/launch/ros_sharp_communication.launch">
 		<arg name="port" value="9090" />
+		<arg name="allow_save" value="false" />
+		<arg name="allow_overwrite" value="false" />
 	</include>
 
 	<arg name="base" default="$(env TURTLEBOT_BASE)" />

--- a/ROS Packages/ROS1/file_server/launch/ros_sharp_communication.launch
+++ b/ROS Packages/ROS1/file_server/launch/ros_sharp_communication.launch
@@ -22,6 +22,9 @@ limitations under the License.
 		<arg name="port" value="9090" />
 	</include>
 
-	<node name="file_server" pkg="file_server" type="file_server" output="screen" />
+	<node pkg="file_server" type="file_server" name="file_server" output="screen">
+		<param name="allow_save"      value="false"/>
+		<param name="allow_overwrite" value="false"/>
+  	</node>
 
 </launch>

--- a/ROS Packages/ROS1/file_server/src/file_server.cpp
+++ b/ROS Packages/ROS1/file_server/src/file_server.cpp
@@ -11,6 +11,11 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+- Added path traversal and extension checks to prevent unauthorized file access.
+- Added parameters to enable/disable saving and overwriting files (disabled by default).
+- Removed auto package generation for security.
+    (C) Siemens AG, 2026, Mehmet Emre Cakal (emre.cakal@siemens.com/m.emrecakal@gmail.com)
 */
 
 #include <ros/ros.h>
@@ -19,144 +24,169 @@ limitations under the License.
 #include <file_server/SaveBinaryFile.h>
 #include <iostream>
 #include <fstream>
-#include <sys/stat.h>
+#include <filesystem>
+#include <unordered_set>
+#include <algorithm>
+
+const std::unordered_set<std::string>& allowed_extensions()
+{
+    static const std::unordered_set<std::string> exts = {
+        ".urdf", ".xacro", ".stl", ".dae", ".obj", ".mtl",
+        ".png",  ".jpg",   ".jpeg",".bmp", ".tga", ".yaml",
+        ".tif",  ".tiff",  ".gif", ".material"
+    };
+    return exts;
+}
+
+bool is_extension_allowed(const std::string& path)
+{
+    auto ext = std::filesystem::path(path).extension().string();
+    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+    return allowed_extensions().count(ext) > 0;
+}
+
+bool has_traversal(const std::string& path)
+{
+    for (const auto& part : std::filesystem::path(path))
+        if (part == ".." || part == ".")
+            return true;
+    return false;
+}
+
+bool is_path_safe(const std::string& base_dir, const std::string& full_path)
+{
+    try 
+    {
+        auto base   = std::filesystem::canonical(base_dir);
+        auto target = std::filesystem::weakly_canonical(full_path);
+        auto [end, _] = std::mismatch(base.begin(), base.end(), target.begin());
+        return end == base.end();
+    } catch (...) 
+    {
+        return false;
+    }
+}
+
+// TODO: need better exception handling
+bool validate_path(const std::string& filepath, const std::string& base_dir, const std::string& full_path)
+{
+    if (has_traversal(filepath)) 
+    {
+        ROS_WARN("Path traversal attempt blocked: %s", full_path.c_str());
+        return false;
+    }
+    if (!is_extension_allowed(filepath)) 
+    {
+        ROS_WARN("Extension not allowed: %s", full_path.c_str());
+        return false;
+    }
+    if (!is_path_safe(base_dir, full_path)) 
+    {
+        ROS_WARN("Path escapes package directory: %s", full_path.c_str());
+        return false;
+    }
+    return true;
+}
+
+bool parse_package_url(const std::string& name, std::string& base_dir, std::string& filepath, std::string& full_path)
+{
+    if (name.compare(0, 10, "package://") != 0) 
+    {
+        ROS_WARN("Only \"package://\" addresses allowed.");
+        return false;
+    }
+    std::string address = name.substr(10);
+    std::string package = address.substr(0, address.find("/"));
+    filepath  = address.substr(package.length());
+    base_dir  = ros::package::getPath(package);
+    full_path = base_dir + filepath;
+    
+    if (base_dir.empty()) 
+    {
+        ROS_WARN("Package not found: %s", package.c_str());
+        return false;
+    }
+    return true;
+}
+
+// callbacks
 
 bool get_file(
-	file_server::GetBinaryFile::Request &req,
-	file_server::GetBinaryFile::Response &res)
+    file_server::GetBinaryFile::Request  &req,
+    file_server::GetBinaryFile::Response &res)
 {
+    std::string base_dir, filepath, full_path;
+    if (!parse_package_url(req.name, base_dir, filepath, full_path)) return true;
+    if (!validate_path(filepath, base_dir, full_path)) return true;
 
-	// analyse request:
-	if (req.name.compare(0,10,"package://")!=0)
-	{
-		ROS_INFO("only \"package://\" addresses allowed.");
-		return true;
-	}	
-	std::string address = req.name.substr(10);
-	std::string package = address.substr(0,address.find("/"));
-	std::string filepath = address.substr(package.length());
-	std::string directory = ros::package::getPath(package);
-	directory+=filepath;
-	
-	// open file:
-	std::ifstream inputfile(directory.c_str(),std::ios::binary);
+    std::ifstream file(full_path, std::ios::binary);
+    if (!file.is_open()) 
+    {
+        ROS_WARN("File not found: %s", full_path.c_str());
+        return true;
+    }
 
-	// stop if file does not exist:
-	if(!inputfile.is_open())
-	{
-		ROS_INFO("file \"%s\" not found.\n", req.name.c_str());
-		return true;
-	}
-
-	// read file contents:	
-	res.value.assign(
-		(std::istreambuf_iterator<char>(inputfile)),
-		std::istreambuf_iterator<char>());
-
-	ROS_INFO("get_file request: %s\n", req.name.c_str());
-	//ROS_INFO("package: %s\n",package.c_str());
-	//ROS_INFO("filepath: %s\n",filepath.c_str());
-	//ROS_INFO("directory: %s\n",directory.c_str());
-
-	return true;
-}
-
-//A recursive method that goes through a path and creates all parent directories
-void create_directories(std::string packagePath, std::string filePath) 
-{
-	if(filePath.size() == 0)
-	{
-		return;
-	}
-	
-	create_directories(packagePath, filePath.substr(0, filePath.find_last_of("/")));
-	
-	struct stat sb;
-	if (!(stat((packagePath + filePath).c_str(), &sb) == 0 && S_ISDIR(sb.st_mode))) //Check if path is already a directory
-	{
-		mkdir((packagePath + filePath).c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-	}
-	
-}
-std::string generate_ros_package(std::string packageName)
-{	
-	std::string catkin_folder = std::getenv("ROS_PACKAGE_PATH");
-	catkin_folder = catkin_folder.substr(0, catkin_folder.find(":"));
-	
-	
-	std::string directory = catkin_folder + "/" + packageName;
-	mkdir(directory.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-	
-	//Create default package.xml file
-	std::string packageXmlContents = "<?xml version=\"1.0\"?>\n<package format=\"2\">\n  <name>" + packageName + "</name>\n  <version>0.0.0</version>\n  <description>The " + packageName + " package</description>\n\n  <maintainer email=\"ros-sharp.ct@siemens.com\">Ros#</maintainer>\n\n  <license>Apache 2.0</license>\n\n  <buildtool_depend>catkin</buildtool_depend>\n  <build_depend>roscpp</build_depend>\n  <build_depend>rospy</build_depend>\n  <build_depend>std_msgs</build_depend>\n  <build_export_depend>roscpp</build_export_depend>\n  <build_export_depend>rospy</build_export_depend>\n  <build_export_depend>std_msgs</build_export_depend>\n  <exec_depend>roscpp</exec_depend>\n  <exec_depend>rospy</exec_depend>\n  <exec_depend>std_msgs</exec_depend>\n\n  <export>\n  </export>\n</package>";
-
-	std::ofstream xmlfile;
-	xmlfile.open ((directory + "/package.xml").c_str(), std::ios::out | std::ios::ate | std::ios::binary);
-	xmlfile << packageXmlContents;
-	xmlfile.close();
-	
-	//Create default CMakeLists.txt file
-	std::string cmakelist_content = "cmake_minimum_required(VERSION 2.8.3)\nproject(" + packageName + ")\n\nfind_package(catkin REQUIRED COMPONENTS\n  roscpp\n  rospy\n  std_msgs\n)\n\ninclude_directories(\n  ${catkin_INCLUDE_DIRS}\n)";
-
-	std::ofstream cmakefile;
-	cmakefile.open ((directory + "/CMakeLists.txt").c_str(), std::ios::out | std::ios::ate | std::ios::binary);
-	cmakefile << cmakelist_content;
-	cmakefile.close();
-
-	return directory;
+    res.value.assign(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+    ROS_INFO("get_file: %s", req.name.c_str());
+    return true;
 }
 
 bool save_file(
-	file_server::SaveBinaryFile::Request &req,
-	file_server::SaveBinaryFile::Response &res)
+    file_server::SaveBinaryFile::Request  &req,
+    file_server::SaveBinaryFile::Response &res)
 {
-	if (req.name.compare(0,10,"package://")!=0)
-	{
-		ROS_INFO("only \"package://\" addresses allowed.");
-		return true;
-	}
-	std::string address = req.name.substr(10);
-	std::string package = address.substr(0,address.find("/"));
-	std::string filepath = address.substr(package.length());
-	std::string directory = ros::package::getPath(package);
+    bool allow_save, allow_overwrite;
+    ros::param::get("~allow_save",      allow_save);
+    ros::param::get("~allow_overwrite", allow_overwrite);
 
-	//Create new ros package if it doesn't already exist
-	if(directory.compare("") == 0)
-	{
-		ROS_INFO("package \"%s\" not found. Creating a new package.", package.c_str());
-		directory = generate_ros_package(package);
-	}
+    if (!allow_save) 
+    {
+        ROS_WARN("Save service is disabled. Enable with parameter \"allow_save\".");
+        return true;
+    }
 
-	create_directories(directory, filepath.substr(0, filepath.find_last_of("/")));
+    std::string base_dir, filepath, full_path;
+    if (!parse_package_url(req.name, base_dir, filepath, full_path)) return true;
+    if (!validate_path(filepath, base_dir, full_path)) return true;
 
-	directory += filepath;
+    if (!allow_overwrite && std::filesystem::exists(full_path)) 
+    {
+        ROS_WARN("Overwrite blocked: %s", full_path.c_str());
+        return true;
+    }
 
-	//Write contents of request to file
-	std::ofstream file_to_save;
-	file_to_save.open (directory.c_str(), std::ios::binary);
+    std::filesystem::create_directories(std::filesystem::path(full_path).parent_path());
 
-	std::string str = "";
-	for(int i=0; i < req.value.size(); i++){ str += req.value[i]; }
- 	file_to_save << str;   
- 	file_to_save.close();
+    std::ofstream file(full_path, std::ios::binary);
+    if (!file.is_open()) 
+    {
+        ROS_ERROR("Failed to open for write: %s", full_path.c_str());
+        return true;
+    }
 
-	ROS_INFO("save_file request: %s", req.name.c_str());
-	//ROS_INFO("package: %s\n",package.c_str());
-	//ROS_INFO("filepath: %s\n",filepath.c_str());
-	//ROS_INFO("directory: %s\n",directory.c_str());
-
-	res.name = req.name;
-
-	return true;
+    file.write(reinterpret_cast<const char*>(req.value.data()), req.value.size());
+    res.name = req.name;
+    ROS_INFO("save_file: %s", req.name.c_str());
+    return true;
 }
+
 int main(int argc, char **argv)
 {
-	ros::init(argc, argv, "file_server");
-	ros::NodeHandle n;
-	ros::ServiceServer serviceServer = n.advertiseService("/file_server/get_file", get_file);
-	ros::ServiceServer serviceServer2 = n.advertiseService("/file_server/save_file", save_file);
-	ROS_INFO("ROSbridge File Server initialized.");
-	ros::spin();
+    ros::init(argc, argv, "file_server");
+    ros::NodeHandle n("~");
 
-	return 0;
+    bool allow_save      = false;
+    bool allow_overwrite = false;
+    n.param("allow_save",      allow_save,      false);
+    n.param("allow_overwrite", allow_overwrite, false);
+
+    ROS_INFO("Save: %s | Overwrite: %s", allow_save ? "enabled" : "disabled",
+             (!allow_save || !allow_overwrite) ? "disabled" : "enabled");
+
+    ros::ServiceServer get_service  = n.advertiseService("/file_server/get_file",  get_file);
+    ros::ServiceServer save_service = n.advertiseService("/file_server/save_file", save_file);
+
+    ROS_INFO("ROS1 File Server initialized.");
+    ros::spin();
+    return 0;
 }

--- a/ROS Packages/ROS2/file_server2/CMakeLists.txt
+++ b/ROS Packages/ROS2/file_server2/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 # Find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
@@ -31,6 +32,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 add_executable(file_server2_node src/file_server.cpp)
 
 ament_target_dependencies(file_server2_node
+  ament_index_cpp
   rclcpp
   std_msgs
 )

--- a/ROS Packages/ROS2/file_server2/launch/publish_description_r2d2.launch.py
+++ b/ROS Packages/ROS2/file_server2/launch/publish_description_r2d2.launch.py
@@ -20,8 +20,17 @@ from ament_index_python.packages import get_package_share_directory
 
 def generate_launch_description():
     # Define launch arguments
-    port_arg = DeclareLaunchArgument('port', default_value='9090', description='Port number for ROS communication')
-    urdf_file_arg = DeclareLaunchArgument('urdf_file', default_value='custom_r2d2.urdf', description='URDF file name')
+    port_arg = DeclareLaunchArgument('port', default_value='9090', 
+                                        description='Port number for ROS communication')
+
+    urdf_file_arg = DeclareLaunchArgument('urdf_file', default_value='custom_r2d2.urdf', 
+                                        description='URDF file name')
+
+    allow_save_arg = DeclareLaunchArgument('allow_save', default_value='false',
+                                        description='Enable saving files (default: false)')
+                                       
+    allow_overwrite_arg = DeclareLaunchArgument('allow_overwrite', default_value='false',
+                                        description='Allow overwrite of existing files (default: false)')
 
     # Define paths
     pkg_file_server2 = get_package_share_directory('file_server2')
@@ -41,7 +50,11 @@ def generate_launch_description():
     # Include ROS Sharp Communication launch file
     ros_sharp_communication_launch = IncludeLaunchDescription(
             PythonLaunchDescriptionSource([rosbridge_server_launch_file]),
-                launch_arguments=[('port', LaunchConfiguration('port'))]
+                launch_arguments={
+                    'port': LaunchConfiguration('port'),
+                    'allow_save': LaunchConfiguration('allow_save'),
+                    'allow_overwrite': LaunchConfiguration('allow_overwrite')
+                }.items()
         )
     
     r2d2_launch = IncludeLaunchDescription(
@@ -60,6 +73,8 @@ def generate_launch_description():
     return LaunchDescription([
         port_arg,
         urdf_file_arg,
+        allow_save_arg,
+        allow_overwrite_arg,
         ros_sharp_communication_launch,
         r2d2_launch,
         # joint_state_publisher_node

--- a/ROS Packages/ROS2/file_server2/launch/publish_description_turtlebot4_lite.launch.py
+++ b/ROS Packages/ROS2/file_server2/launch/publish_description_turtlebot4_lite.launch.py
@@ -19,7 +19,14 @@ from ament_index_python.packages import get_package_share_directory
 
 def generate_launch_description():
     # Define launch arguments
-    port_arg = DeclareLaunchArgument('port', default_value='9090', description='Port number for ROS communication')
+    port_arg = DeclareLaunchArgument('port', default_value='9090',
+                                        description='Port number for ROS communication')
+
+    allow_save_arg = DeclareLaunchArgument('allow_save', default_value='false',
+                                        description='Enable saving files (default: false)')
+                                       
+    allow_overwrite_arg = DeclareLaunchArgument('allow_overwrite', default_value='false',
+                                        description='Allow overwrite of existing files (default: false)')
 
     # Define paths
     pkg_file_server2 = get_package_share_directory('file_server2')
@@ -34,7 +41,11 @@ def generate_launch_description():
     # Include ROS Sharp Communication launch file
     ros_sharp_communication_launch = IncludeLaunchDescription(
             PythonLaunchDescriptionSource([rosbridge_server_launch_file]),
-                launch_arguments=[('port', LaunchConfiguration('port'))]
+                launch_arguments={
+                    'port': LaunchConfiguration('port'),
+                    'allow_save': LaunchConfiguration('allow_save'),
+                    'allow_overwrite': LaunchConfiguration('allow_overwrite')
+                }.items()
         )
     
     tb4_standard_launch = IncludeLaunchDescription(
@@ -43,6 +54,8 @@ def generate_launch_description():
     
     return LaunchDescription([
         port_arg,
+        allow_save_arg,
+        allow_overwrite_arg,
         ros_sharp_communication_launch,
         tb4_standard_launch
     ])

--- a/ROS Packages/ROS2/file_server2/launch/publish_description_turtlebot4_standard.launch.py
+++ b/ROS Packages/ROS2/file_server2/launch/publish_description_turtlebot4_standard.launch.py
@@ -19,7 +19,15 @@ from ament_index_python.packages import get_package_share_directory
 
 def generate_launch_description():
     # Define launch arguments
-    port_arg = DeclareLaunchArgument('port', default_value='9090', description='Port number for ROS communication')
+    port_arg = DeclareLaunchArgument('port', default_value='9090',
+                                        description='Port number for ROS communication')
+
+    allow_save_arg = DeclareLaunchArgument('allow_save', default_value='false',
+                                        description='Enable saving files (default: false)')
+                                       
+    allow_overwrite_arg = DeclareLaunchArgument('allow_overwrite', default_value='false',
+                                        description='Allow overwrite of existing files (default: false)')
+
 
     # Define paths
     pkg_file_server2 = get_package_share_directory('file_server2')
@@ -34,7 +42,11 @@ def generate_launch_description():
     # Include ROS Sharp Communication launch file
     ros_sharp_communication_launch = IncludeLaunchDescription(
             PythonLaunchDescriptionSource([rosbridge_server_launch_file]),
-                launch_arguments=[('port', LaunchConfiguration('port'))]
+                launch_arguments={
+                    'port': LaunchConfiguration('port'),
+                    'allow_save': LaunchConfiguration('allow_save'),
+                    'allow_overwrite': LaunchConfiguration('allow_overwrite')
+                }.items()
         )
     
     tb4_standard_launch = IncludeLaunchDescription(
@@ -43,6 +55,8 @@ def generate_launch_description():
     
     return LaunchDescription([
         port_arg,
+        allow_save_arg,
+        allow_overwrite_arg,
         ros_sharp_communication_launch,
         tb4_standard_launch
     ])

--- a/ROS Packages/ROS2/file_server2/launch/ros_sharp_communication.launch.py
+++ b/ROS Packages/ROS2/file_server2/launch/ros_sharp_communication.launch.py
@@ -21,20 +21,28 @@ from ament_index_python.packages import get_package_share_directory
 def generate_launch_description():
     # Define launch arguments
     port_arg = DeclareLaunchArgument('port', 
-                                     default_value='9090', 
-                                     description='Port number for ROS communication (default: 9090)')
+                                    default_value='9090', 
+                                    description='Port number for ROS communication (default: 9090)')
     
     fragment_timeout_arg = DeclareLaunchArgument('fragment_timeout',
-                                                  default_value='600', 
-                                                  description='Timeout for fragment reassembly in seconds (default: 600)')
+                                    default_value='600', 
+                                    description='Timeout for fragment reassembly in seconds (default: 600)')
     
     unregister_timeout_arg = DeclareLaunchArgument('unregister_timeout',
-                                                   default_value='10.0',
-                                                   description='Timeout for unregistering in seconds (default: 10.0)')
+                                    default_value='10.0',
+                                    description='Timeout for unregistering in seconds (default: 10.0)')
     
     max_message_size_arg = DeclareLaunchArgument('max_message_size',
-                                                 default_value='100000000',
-                                                 description='Maximum message size in bytes (default: 10000000)')
+                                    default_value='100000000',
+                                    description='Maximum message size in bytes (default: 10000000)')
+
+    allow_save_arg = DeclareLaunchArgument('allow_save',
+                                    default_value='false',
+                                    description='Enable saving files (default: false)')
+
+    allow_overwrite_arg = DeclareLaunchArgument('allow_overwrite',
+                                    default_value='false',
+                                    description='Allow overwrite of existing files (default: false)')
 
     pkg_rosbridge_server = get_package_share_directory('rosbridge_server')
 
@@ -46,6 +54,8 @@ def generate_launch_description():
         fragment_timeout_arg,
         unregister_timeout_arg,
         max_message_size_arg,
+        allow_save_arg,
+        allow_overwrite_arg,
 
         IncludeLaunchDescription(
             FrontendLaunchDescriptionSource([rosbridge_server_launch]),
@@ -60,7 +70,11 @@ def generate_launch_description():
         Node(
             package='file_server2',
             executable='file_server2_node',
-            output='screen'
+            output='screen',
+            parameters=[
+                {'allow_save': LaunchConfiguration('allow_save')},
+                {'allow_overwrite': LaunchConfiguration('allow_overwrite')}
+            ]
         )
         
     ])

--- a/ROS Packages/ROS2/file_server2/src/file_server.cpp
+++ b/ROS Packages/ROS2/file_server2/src/file_server.cpp
@@ -15,7 +15,13 @@ limitations under the License.
 - Added ROS2 support.
 - Added mutex and lock guards to make the save_file_callback thread-safe.
     (C) Siemens AG, 2024, Mehmet Emre Cakal (emre.cakal@siemens.com/m.emrecakal@gmail.com)
+
+- Added path traversal and extension checks to prevent unauthorized file access.
+- Added parameters to enable/disable saving and overwriting files (disabled by default).
+- Removed auto package generation for security.
+    (C) Siemens AG, 2026, Mehmet Emre Cakal (emre.cakal@siemens.com/m.emrecakal@gmail.com)
 */
+
 
 #include <rclcpp/rclcpp.hpp>
 #include <ament_index_cpp/get_package_share_directory.hpp>
@@ -25,8 +31,9 @@ limitations under the License.
 #include <fstream>
 #include <sys/stat.h>
 #include <mutex>
-#include <thread>
-#include <string>
+#include <filesystem>
+#include <unordered_set>
+#include <algorithm>
 
 using namespace std::placeholders;
 
@@ -35,6 +42,9 @@ class FileServerNode : public rclcpp::Node
 public:
     FileServerNode() : Node("file_server")
     {
+        this->declare_parameter("allow_save",      false);
+        this->declare_parameter("allow_overwrite", false);
+
         get_file_service_ = this->create_service<file_server2::srv::GetBinaryFile>(
             "/file_server/get_file",
             std::bind(&FileServerNode::get_file_callback, this, _1, _2));
@@ -42,75 +52,126 @@ public:
         save_file_service_ = this->create_service<file_server2::srv::SaveBinaryFile>(
             "/file_server/save_file",
             std::bind(&FileServerNode::save_file_callback, this, _1, _2));
+        
+        if (this->get_parameter("allow_save").as_bool())
+        {
+            RCLCPP_INFO(this->get_logger(), "Save enabled. Overwrite: %s",
+                this->get_parameter("allow_overwrite").as_bool() ? "yes" : "no");
+        }
+        else
+        {
+            RCLCPP_INFO(this->get_logger(), "Save disabled.");
+        }
 
         RCLCPP_INFO(this->get_logger(), "ROS2 File Server initialized.");
     }
 
 private:
+    static const std::unordered_set<std::string>& allowed_extensions()
+    {
+        static const std::unordered_set<std::string> exts = 
+        {
+            ".urdf", ".xacro", ".stl", ".dae", ".obj", ".mtl",
+            ".png",  ".jpg",   ".jpeg",".bmp", ".tga", ".yaml",
+            ".tif",  ".tiff",  ".gif", ".material"
+        };
+        return exts;
+    }
+
+    bool is_extension_allowed(const std::string& path)
+    {
+        auto ext = std::filesystem::path(path).extension().string();
+        std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+        return allowed_extensions().count(ext) > 0;
+    }
+
+    bool has_traversal(const std::string& path)
+    {
+        for (const auto& part : std::filesystem::path(path))
+            if (part == ".." || part == ".")
+                return true;
+        return false;
+    }
+
+    bool is_path_safe(const std::string& base_dir, const std::string& full_path)
+    {
+        try 
+        {
+            auto base   = std::filesystem::canonical(base_dir);
+            auto target = std::filesystem::weakly_canonical(full_path);
+            auto [end, _] = std::mismatch(base.begin(), base.end(), target.begin());
+            return end == base.end();
+        } catch (...) 
+        {
+            return false;
+        }
+    }
+
+    bool validate_path(const std::string& filepath, const std::string& base_dir, const std::string& full_path)
+    {
+        if (has_traversal(filepath)) 
+        {
+            RCLCPP_WARN(this->get_logger(), "Path traversal attempt blocked: %s", full_path.c_str());
+            return false;
+        }
+        if (!is_extension_allowed(filepath))
+        {
+            RCLCPP_WARN(this->get_logger(), "Extension not allowed: %s", full_path.c_str());
+            return false;
+        }
+        if (!is_path_safe(base_dir, full_path)) 
+        {
+            RCLCPP_WARN(this->get_logger(), "Path escapes package directory: %s", full_path.c_str());
+            return false;
+        }
+        return true;
+    }
+
+
+    bool parse_package_url(const std::string& name, std::string& base_dir, std::string& filepath, std::string& full_path)
+    {
+        if (name.compare(0, 10, "package://") != 0) 
+        {
+            RCLCPP_WARN(this->get_logger(), "Only \"package://\" addresses allowed.");
+            return false;
+        }
+        
+        std::string address = name.substr(10);
+        std::string package = address.substr(0, address.find("/"));
+        filepath = address.substr(package.length());
+
+        // TODO: need better exception handling
+        try 
+        {
+            base_dir = ament_index_cpp::get_package_share_directory(package);
+        } catch (...) 
+        {
+            base_dir = "";
+        }
+        full_path = base_dir + filepath;
+        return true;
+    }
+
+    // callbacks
+
     void get_file_callback(
         const std::shared_ptr<file_server2::srv::GetBinaryFile::Request> request,
         std::shared_ptr<file_server2::srv::GetBinaryFile::Response> response)
     {
-        if (request->name.compare(0, 10, "package://") != 0)
-        {
-            RCLCPP_INFO(this->get_logger(), "Only \"package://\" addresses allowed.");
-            return;
+        std::string base_dir, filepath, full_path;
+        if (!parse_package_url(request->name, base_dir, filepath, full_path)) return;
+        if (base_dir.empty()) { RCLCPP_WARN(this->get_logger(), "Package not found."); return; }
+        if (!validate_path(filepath, base_dir, full_path)) return;
+
+        std::ifstream file(full_path, std::ios::binary);
+        if (!file.is_open()) 
+        { 
+            RCLCPP_WARN(this->get_logger(), "File not found: %s", full_path.c_str()); 
+            return; 
         }
 
-        std::string address = request->name.substr(10);
-        std::string package = address.substr(0, address.find("/"));
-        std::string filepath = address.substr(package.length());
-        std::string directory = ament_index_cpp::get_package_share_directory(package);
-        directory += filepath;
-
-        std::ifstream inputfile(directory.c_str(), std::ios::binary);
-        if (!inputfile.is_open())
-        {
-            RCLCPP_INFO(this->get_logger(), "File \"%s\" not found.", request->name.c_str());
-            return;
-        }
-
-        response->value.assign(
-            std::istreambuf_iterator<char>(inputfile),
-            std::istreambuf_iterator<char>());
-
-        RCLCPP_INFO(this->get_logger(), "get_file request: %s", request->name.c_str());
-    }
-
-    void create_directories(const std::string& packagePath, const std::string& filePath)
-    {
-        if (filePath.empty())
-        {
-            return;
-        }
-
-        create_directories(packagePath, filePath.substr(0, filePath.find_last_of("/")));
-
-        struct stat sb;
-        if (!(stat((packagePath + filePath).c_str(), &sb) == 0 && S_ISDIR(sb.st_mode)))
-        {
-            mkdir((packagePath + filePath).c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-        }
-    }
-
-    std::string generate_ros_package(const std::string& packageName)
-    {
-        std::string package_share_dir = ament_index_cpp::get_package_share_directory(packageName);
-        std::string directory = package_share_dir;
-
-        std::string packageXmlContents = "<?xml version=\"1.0\"?>\n<package format=\"2\">\n  <name>" + packageName + "</name>\n  <version>0.0.0</version>\n  <description>The " + packageName + " package</description>\n\n  <maintainer email=\"ros-sharp.ct@siemens.com\">Ros#</maintainer>\n\n  <license>Apache 2.0</license>\n\n  <buildtool_depend>ament_cmake</buildtool_depend>\n  <build_depend>rclcpp</build_depend>\n  <exec_depend>rclcpp</exec_depend>\n\n  <export>\n  </export>\n</package>";
-
-        std::ofstream xmlfile(directory + "/package.xml", std::ios::out | std::ios::binary);
-        xmlfile << packageXmlContents;
-        xmlfile.close();
-
-        std::string cmakelist_content = "cmake_minimum_required(VERSION 3.5)\nproject(" + packageName + ")\n\nfind_package(ament_cmake REQUIRED)\nfind_package(rclcpp REQUIRED)\n\nadd_executable(" + packageName + "_node src/" + packageName + "_node.cpp)\nament_target_dependencies(" + packageName + "_node rclcpp)\n\ninstall(TARGETS " + packageName + "_node\n  DESTINATION lib/" + packageName + ")\n\nament_package()";
-
-        std::ofstream cmakefile(directory + "/CMakeLists.txt", std::ios::out | std::ios::binary);
-        cmakefile << cmakelist_content;
-        cmakefile.close();
-
-        return directory;
+        response->value.assign(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+        RCLCPP_INFO(this->get_logger(), "get_file: %s", request->name.c_str());
     }
 
     void save_file_callback(
@@ -118,43 +179,35 @@ private:
         std::shared_ptr<file_server2::srv::SaveBinaryFile::Response> response)
     {
         std::lock_guard<std::mutex> guard(save_file_mutex_);
-
-        RCLCPP_INFO(this->get_logger(), "save_file request: %s", request->name.c_str());
-
-        if (request->name.compare(0, 10, "package://") != 0)
+        if (!this->get_parameter("allow_save").as_bool()) 
         {
-            RCLCPP_INFO(this->get_logger(), "Only \"package://\" addresses allowed.");
+            RCLCPP_WARN(this->get_logger(), "Save service is disabled. Enable with parameter \"allow_save\".");
             return;
         }
 
-        std::string address = request->name.substr(10);
-        std::string package = address.substr(0, address.find("/"));
-        std::string filepath = address.substr(package.length());
-        std::string directory;
+        // TODO: need better exception handling
+        std::string base_dir, filepath, full_path;
+        if (!parse_package_url(request->name, base_dir, filepath, full_path)) return;
+        if (!validate_path(filepath, base_dir, full_path)) return;
 
-        try {
-            directory = ament_index_cpp::get_package_share_directory(package);
-        } catch (const std::exception &e) {
-            RCLCPP_INFO(this->get_logger(), "Package \"%s\" not found. Creating a new package.", package.c_str());
-            directory = generate_ros_package(package);
-        }
-
-        create_directories(directory, filepath.substr(0, filepath.find_last_of("/")));
-        directory += filepath;
-
-        std::ofstream file_to_save(directory.c_str(), std::ios::binary);
-        if (!file_to_save.is_open())
+        if (!this->get_parameter("allow_overwrite").as_bool() && std::filesystem::exists(full_path))
         {
-            RCLCPP_ERROR(this->get_logger(), "Failed to open file: %s", directory.c_str());
+            RCLCPP_WARN(this->get_logger(), "Overwrite blocked: %s", full_path.c_str());
             return;
         }
 
-        file_to_save.write(reinterpret_cast<const char*>(request->value.data()), request->value.size());
-        file_to_save.close();
+        std::filesystem::create_directories(std::filesystem::path(full_path).parent_path());
 
+        std::ofstream file(full_path, std::ios::binary);
+        if (!file.is_open()) 
+        { 
+            RCLCPP_ERROR(this->get_logger(), "Failed to open for write: %s", full_path.c_str()); 
+            return; 
+        }
+
+        file.write(reinterpret_cast<const char*>(request->value.data()), request->value.size());
         response->name = request->name;
-
-        RCLCPP_INFO(this->get_logger(), "save_file request completed: %s", request->name.c_str());
+        RCLCPP_INFO(this->get_logger(), "save_file: %s", request->name.c_str());
     }
 
     rclcpp::Service<file_server2::srv::GetBinaryFile>::SharedPtr get_file_service_;
@@ -165,12 +218,10 @@ private:
 int main(int argc, char **argv)
 {
     rclcpp::init(argc, argv);
-
     auto node = std::make_shared<FileServerNode>();
     rclcpp::executors::MultiThreadedExecutor executor;
     executor.add_node(node);
     executor.spin();
-
     rclcpp::shutdown();
     return 0;
 }


### PR DESCRIPTION
## [2.2.2] - 22.04.2026

### Security (file_server)
- **Path validation**: Block path-traversal (`.` / `..`) and enforce `package://` addresses.  
- **Extension whitelist**: Only allow safe extensions (e.g. `.urdf`, `.stl`, `.png`, `.yaml`, `.dae`, `.obj`, `.mtl`, etc.).  
- **Canonical checks**: Use canonical/weakly_canonical comparisons to ensure target stays inside the package share directory.  

### Added (file_server)
- **Parameter control**: Disable saving and overwriting by default.
  - `allow_save`: enables `file_server/save_file` service (default: `false`).  
  - `allow_overwrite`: allows overwriting existing files (default: `false`).
  
 - C++17 support for `stdc++fs` (`ROS1/file_server`)
 - ROS2 Jazzy support w/ `ament_index_cpp` (`ROS2/file_server`, thank you @lreiher! (PR #489))

### Removed (file_server)
- **Auto package generation**: Remove `generate_ros_package` and the old recursive `create_directories`; directory creation is now explicit and permissioned via `std::filesystem::create_directories`.